### PR TITLE
Create and edit users, and manage user passwords

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
         'Dancer2'     => 0.15,
         'Crypt::SaltedHash' => 0,
         'YAML'       => 0, # for config files (TODO: make optional?)
-        'String::Random' => 0,
+        'Session::Token' => 0,
     },
     EXE_FILES => [ 'bin/generate-crypted-password' ],
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
         'Dancer2'     => 0.15,
         'Crypt::SaltedHash' => 0,
         'YAML'       => 0, # for config files (TODO: make optional?)
+        'String::Random' => 0,
     },
     EXE_FILES => [ 'bin/generate-crypted-password' ],
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -624,7 +624,7 @@ sub create_user {
 register create_user => \&create_user;
 
 
-=item password_reset_send - email a password reset request
+=item password_reset_send
 
 C<password_reset_send> sends a user an email with a password reset link. Along
 with C<user_password>, it allows a user to reset their password.
@@ -771,7 +771,7 @@ sub password_reset_send {
 register password_reset_send => \&password_reset_send;
 
 
-=item user_password - manage a user's password
+=item user_password
 
 This provides various functions to check or reset a user's password, either
 from a reset code that was previously send by L<password_reset_send> or

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -6,7 +6,7 @@ use strict;
 use Carp;
 use Dancer2::Plugin;
 use Class::Load qw(try_load_class);
-use String::Random;
+use Session::Token;
 
 our $VERSION = '0.306';
 
@@ -1138,8 +1138,7 @@ sub _post_login_route {
         && $app->request->param('confirm_reset')
         && $app->request->splat;
     if ($code) {
-        my $gen = String::Random->new;
-        my $randompw = scalar $gen->randregex('\w{8}');
+        my $randompw = Session::Token->new(length => 8)->get;
         if (user_password($app, code => $code, new_password => $randompw)) {
             $app->forward($loginpage, { new_password => $randompw }, { method => 'GET' });
         }
@@ -1390,9 +1389,7 @@ sub _smart_match {
 }
 
 sub _reset_code {
-    my $gen = String::Random->new;
-    $gen->{'A'} = [ 'A'..'Z', 'a'..'z' ];
-    scalar $gen->randregex('\w{32}');
+    Session::Token->new(length => 32)->get;
 }
 
 

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -536,6 +536,30 @@ sub update_user {
 register update_user => \&update_user;
 
 
+=item update_current_user
+
+The same as L<update_user>, but does not take a username as the first parameter,
+instead updating the currently logged-in user.
+
+    # Update user, only one realm configured
+    update_current_user surname => "Smith"
+
+The updated user's details are returned, as per L<logged_in_user>.
+
+=cut
+
+sub update_current_user {
+    my ($dsl, %update) = @_;
+
+    if (my $username = $dsl->app->session->read('logged_in_user')) {
+        update_user($dsl, $username, %update);
+    } else {
+        $dsl->app->log( debug  => "Could not update current user as no user currently logged in" );
+    }
+}
+register update_current_user => \&update_current_user;
+
+
 =item create_user
 
 Creates a new user, if the authentication provider supports it. Optionally

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -815,8 +815,6 @@ Force set a specific user's password, without checking existing password:
 
     user_password username => 'jbloggs', new_password => 'secret'
 
-=back
-
 =cut
 
 sub user_password {

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -827,8 +827,8 @@ sub user_password {
                         : (keys %{ $settings->{realms} });
 
     # Expect either a code, username or nothing (for logged-in user)
-    if (my $code = $params{code}) {
-
+    if (exists $params{code}) {
+        my $code = $params{code} or return;
         foreach my $realm_check (@realms_to_check) {
             my $provider = auth_provider($dsl, $realm_check);
             # Realm may not support get_user_by_code

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -499,49 +499,33 @@ register authenticate_user => \&authenticate_user;
 Updates a user's details. If the authentication provider supports it, this
 keyword allows a user's details to be updated within the backend data store.
 
-In order to update the user's details, the keyword should be called with a
-hash of the values to be updated. Note that whilst the password can be
-updated using this method, any new value will be stored directly into the
-provider as-is, not encrypted. It is recommended to use L<user_password>
-instead.
+In order to update the user's details, the keyword should be called with the
+username to be updated, followed by a hash of the values to be updated. Note
+that whilst the password can be updated using this method, any new value will
+be stored directly into the provider as-is, not encrypted. It is recommended to
+use L<user_password> instead.
 
-By default the current logged in user is updated. However, if a different
-user is to be updated, then specify a username key and value as the first
-parameter. In that case, the realm also needs to be specified using the key
-C<realm>. To update the username, specify its new value as a second username
-key.
+If only one realm is configured then this will be used to search for the user.
+Otherwise, the realm must be specified with the realm key.
 
-    # Update current user
-    update_user surname => "Smith"
+    # Update user, only one realm configured
+    update_user "jsmith", surname => "Smith"
 
-    # Update specific user, not necessarily logged in
-    update_user username => "jsmith", realm => "dbic", surname => "Smith"
-
-    # Update a specific user's username
-    update_user username => "jsmith", realm => "dbic", username => "jjones"
+    # Update a user's username, more than one realm
+    update_user "jsmith", realm => "dbic", username => "jjones"
 
 The updated user's details are returned, as per L<logged_in_user>.
 
 =cut
 
 sub update_user {
-    my $dsl     = shift;
+    my ($dsl, $username, %update) = @_;
 
-    # Is a different user specified for the update?
-    my $username; my $realm; my %update;
-    if ($_[0] eq 'username') {
-        $username = shift && shift;
-        %update   = @_;
-        $realm    = delete $update{realm}
-            or die "User's realm needs to be specified when using username for update";
-    } else {
-        %update     = @_;
-        my $session = $dsl->app->session;
-        $username   = $session->read('logged_in_user')
-            or die "No user currently logged in to update";
-        $realm      = $session->read('logged_in_user_realm');
-    }
+    my @all_realms = keys %{ $settings->{realms} };
+    die "Realm must be specified when more than one realm configured"
+        if !$update{realm} && @all_realms > 1;
 
+    my $realm    = delete $update{realm} || $all_realms[0];
     my $provider = auth_provider($dsl, $realm);
     $provider->set_user_details($username, %update);
 }

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -551,8 +551,10 @@ The updated user's details are returned, as per L<logged_in_user>.
 sub update_current_user {
     my ($dsl, %update) = @_;
 
-    if (my $username = $dsl->app->session->read('logged_in_user')) {
-        update_user($dsl, $username, %update);
+    my $session = $dsl->app->session;
+    if (my $username = $session->read('logged_in_user')) {
+        my $realm    = $session->read('logged_in_user_realm');
+        update_user($dsl, $username, realm => $realm, %update);
     } else {
         $dsl->app->log( debug  => "Could not update current user as no user currently logged in" );
     }

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -215,8 +215,12 @@ and should do at least the following:
         session->destroy;
     };
     
+
 If you want to use the default C<post '/login'> and C<any '/logout'> routes
 you can configure them. See below.
+
+The default routes also contain functionality for a user to perform password
+resets. See the L<PASSWORD RESETS> documentation for more details.
 
 =head2 Keywords
 
@@ -886,6 +890,54 @@ register user_password=> \&user_password;
 
 =back
 
+=head2 PASSWORD RESETS
+
+A variety of functionality is provided to make it easier to manage requests
+from users to reset their passwords. The keywords L<password_reset_send> and
+L<user_password> form the core of this functionality - see the documentation of
+these keywords for full details. This functionality can only be used with a
+provider that supports write access.
+
+When utilising this functionality, it is wise to only allow passwords to be
+reset with a POST request. This is because some email scanners "open" links
+before delivering the email to the end user. With only a single-use GET
+request, this will result in the link being "used" by the time it reaches the
+end user, thus rendering it invalid.
+
+Password reset functionality is also built-in to the default route handlers.
+To enable this, set the configuration value C<reset_password_handler> to a true
+value (having already configured the mail handler, as per the keyword
+documentation above). Once this is done, the default login page will contain
+additional form controls to allow the user to enter their username and request
+a reset password link.
+
+If using C<login_page_handler> to replace the default login page, you can still
+use the default password reset handlers. Add 2 controls to your form for
+submitting a password reset request: a text input called username_reset for the
+username, and submit_reset to submit the request. Your login_page_handler is
+then passed the following additional params:
+
+=over
+
+=item new_password
+
+Contains the new automatically-generated password, once the password reset has
+been performed successfully.
+
+=item reset_sent
+
+Is true when a password reset has been emailed to the user.
+
+=item password_code_valid
+
+Is true when a valid password reset code has been submitted with a GET request.
+In this case, the user should be given the chance to confirm with a POST
+request, with a form control called C<confirm_reset>.
+
+For a full example, see the default handler in this module's code.
+
+=back
+
 =head2 SAMPLE CONFIGURATION
 
 In your application's configuation file:
@@ -906,6 +958,9 @@ In your application's configuation file:
                 options:              # Options for module
                     via: sendmail     # Options passed to $msg->send
             mail_from: '"App name" <myapp@example.com>' # From email address
+
+            # Set to true to enable password reset code in the default handlers
+            reset_password_handler: 1
 
             # Password reset functionality
             password_reset_send_email: My::App::reset_send # Customise sending sub

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1023,7 +1023,7 @@ on_plugin_import {
 
                 my ($code) = $dsl->request->splat; # Reset password code submitted?
                 if ($settings->{reset_password_handler} && user_password($dsl, code => $code)) {
-                    $app->request->vars->{password_code_valid} = 1;
+                    $app->request->params->{password_code_valid} = 1;
                 } else {
                     $dsl->response->status(401);
                 }
@@ -1176,7 +1176,7 @@ SENT
 
     # Valid password reset request. Just need to confirm to
     # prevent GET requests by email filters
-    if ($dsl->request->vars->{password_code_valid}) {
+    if ($dsl->request->param('password_code_valid')) {
         return <<VALID;
 <h1>Reset your password</h1>
 <p>

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -532,7 +532,7 @@ sub update_user {
 register update_user => \&update_user;
 
 
-=item create_user - create a new user
+=item create_user
 
 Creates a new user, if the authentication provider supports it. Optionally
 sends a welcome message with a password reset request, in which case an

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -618,7 +618,10 @@ sub create_user {
     my $provider = auth_provider($dsl, $realm);
     # Prevent duplicate users. Would be nice to make this an exception,
     # but that's not in keeping with other functions of this module
-    return if $provider->get_user_details($options{username});
+    if ($provider->get_user_details($options{username})) {
+        $dsl->app->log( info  => "User $options{username} already exists. Not creating." );
+        return;
+    }
     my $user = $provider->create_user(%options);
     if ($email_welcome) {
         my $_welcome_send =

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
@@ -67,6 +67,7 @@ sub match_password {
     for my $method (qw(
         authenticate_user
         get_user_details
+        set_user_details
         get_user_roles
         ))
     {

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
@@ -60,6 +60,16 @@ sub match_password {
 }
 
 
+sub encrypt_password {
+    my ($self, $password, $algorithm) = @_;
+    $algorithm ||= 'SHA-1';
+    my $crypt = Crypt::SaltedHash->new(algorithm => $algorithm);
+    $crypt->add($password);
+    $crypt->generate;
+}
+
+
+
 # Install basic method placeholders which will blow up if the provider module
 # did not implement their own version. 
 {
@@ -69,6 +79,7 @@ sub match_password {
         get_user_details
         set_user_details
         get_user_roles
+        set_user_password
         ))
     {
         *$method = sub {


### PR DESCRIPTION
This rather large PR adds a bunch of functionality to manage users and their passwords.

It creates the following new keywords:

* ```update_user``` - update a user, assuming the backend supports it. Here is an example for the DBIC provider: https://github.com/ctrlo/Dancer2-Plugin-Auth-Extensible-Provider-DBIC/commit/6fb8caab827564c009962f35862084d4b5b9dbf0
* ```create_user``` - create a new user, and optionally send them a welcome email with "set password" link.
* ```password_reset_send``` - send a password reset request email to a user, with a link to reset their password.
* ```user_password``` - various functions to manage a user's password, including processing of a password reset request.

Sorry for the rather meaty PR, but much of the functionality depends on each other.