### PR TITLE
Fix no_default_pages and no_login_handler options

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -616,8 +616,24 @@ on_plugin_import {
                     $settings->{login_page_handler} || '_default_login_page';
                 no strict 'refs';
                 return &{$_default_login_page}($dsl);
-            });
+            }
+        );
 
+        $app->add_route(
+            method => 'get',
+            regexp => $deniedpage,
+            code => sub {
+                $dsl->response->status(403);
+                my $_default_permission_denied_page =
+                    $settings->{permission_denied_page_handler}
+                    || '_default_permission_denied_page';
+                no strict 'refs';
+                return &{$_default_permission_denied_page}($dsl);
+            }
+        );
+    }
+
+    if ( !$settings->{no_login_handler} ) {
         $app->add_route(
             method => 'post',
             regexp => $loginpage,
@@ -631,18 +647,6 @@ on_plugin_import {
                 code => \&_logout_route,
             );
         }
-
-        $app->add_route(
-            method => 'get',
-            regexp => $deniedpage,
-            code => sub {
-                $dsl->response->status(403);
-                my $_default_permission_denied_page =
-                    $settings->{permission_denied_page_handler}
-                    || '_default_permission_denied_page';
-                no strict 'refs';
-                return &{$_default_permission_denied_page}($dsl);
-            });
     }
 };
 


### PR DESCRIPTION
* no_default_pages incorrectly removes POST login and ANY logout routes.
* no_login_handlers did not exist, but should do the above.
See #9 
Untested - @hvoers can you test please?