### PR TITLE
Fix failed to send return when user not found during PW reset

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -776,8 +776,8 @@ sub password_reset_send {
         my $provider = auth_provider($dsl, $realm);
         # Generate random string for the password reset URL
         my $code = _reset_code(); my $user;
-        my $ret = eval { $user = $provider->set_user_details($username, pw_reset_code => $code) };
-        unless ($ret) {
+        eval { $user = $provider->set_user_details($username, pw_reset_code => $code) };
+        if ($@) {
             $dsl->app->log( debug  => "Failed to set_user_details with $realm: $@" );
             next;
         }


### PR DESCRIPTION
In the event of a user not being found (unable to set user details) the user_password function was returning undef (failed to send email) rather than 0, for no emails sent. This fixes that.

It uses the "sometimes to be avoided" $@ return value with eval, but I believe it is fine in this circumstance.