### PR TITLE
was using requires_login instead of require_login

### DIFF
--- a/t/lib/Dancer2/Plugin/InsidePlugin.pm
+++ b/t/lib/Dancer2/Plugin/InsidePlugin.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Dancer2::Plugin2;
-use Dancer2::Plugin::Auth::Extensible;
+use Dancer2::Plugin::Auth::Extensible ();
 
 has auth_extensible => (
     is => 'ro',
@@ -12,7 +12,7 @@ has auth_extensible => (
     default => sub {
         scalar $_[0]->app->with_plugins( 'Auth::Extensible' )
     },
-    handles => { 'requires_login' => 'requires_login' },
+    handles => [ 'require_login' ],
 );
 
 sub members_route {
@@ -26,7 +26,7 @@ sub BUILD {
         method => 'get',
         regexp => '/members',
         code   => sub {
-            $plugin->requires_login(
+            $plugin->require_login(
                 \&members_route
             )
         });


### PR DESCRIPTION
Since in the plugin I made you use 
`[ require_login, requires_login]`

The former is the real method, while the latter is only a keyword alias (i.e., it doesn't exist as a duplicate function).