### PR TITLE
config needs to be in the app space

### DIFF
--- a/t/02-as-plugin.t
+++ b/t/02-as-plugin.t
@@ -7,17 +7,22 @@ use Test::WWW::Mechanize::PSGI;
 use lib 't/lib';
 
 use Dancer2;
+
 use InsidePluginApp;
 
-set plugins => {
-    "Auth::Extensible" => {
-        realms => {
-            config => {
-                provider => 'Config',
+{
+    package InsidePluginApp;
+
+    set plugins => {
+        "Auth::Extensible" => {
+            realms => {
+                config => {
+                    provider => 'Config',
+                }
             }
         }
-    }
-};
+    };
+}
 
 my $mech = Test::WWW::Mechanize::PSGI->new(
     app => InsidePluginApp->to_app


### PR DESCRIPTION
I don't think that one is due to the new plugins. The `set plugins` needs to be called in the right app's namespace.