### PR TITLE
Allow priority attribute to force order in which realms are checked.

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
@@ -165,6 +165,38 @@ sub _test_base {
               or diag explain $trap->read;
         }
 
+        SKIP: {
+            skip "priorities not defined for this provider test", 1
+              if !defined $ENV{DANCER_ENVIRONMENT}
+              || $ENV{DANCER_ENVIRONMENT} ne 'provider-config';
+
+            # test realm priority
+            # TODO: find out if we can run these tests by poking the 
+            # provider rather than having it hard-coded.
+            my $logs = $trap->read;
+            cmp_deeply(
+                $logs,
+                [
+                    {
+                        formatted => ignore(),
+                        level     => 'debug',
+                        message   => re(qr/realm config2/)
+                    },
+                    {
+                        formatted => ignore(),
+                        level     => 'debug',
+                        message   => re(qr/realm config3/)
+                    },
+                    {
+                        formatted => ignore(),
+                        level     => 'debug',
+                        message   => re(qr/realm config1/)
+                    },
+                ],
+                "Realms checked in the correct order"
+            ) or diag explain $logs;
+        }
+
         my @headers;
 
         # ... and that we can log in with real details

--- a/t/lib/environments/provider-config.yml
+++ b/t/lib/environments/provider-config.yml
@@ -17,8 +17,15 @@ plugins:
                           - CiderDrinker
             config2:
                 provider: Config
+                priority: 10
                 users:
                     - user: burt
                       pass: bacharach
                     - user: hashedpassword
                       pass: "{SSHA}+2u1HpOU7ak6iBR6JlpICpAUvSpA/zBM"
+            config3:
+                provider: Config
+                priority: 2
+                users:
+                    - user: bananarepublic
+                      pass: whatever

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -27,7 +27,7 @@ pod_coverage_ok(
             qw/
               BUILDARGS BUILD ClassHooks PluginKeyword dancer_app
               execute_plugin_hook hook keywords on_plugin_import plugin_args
-              plugin_setting realm_providers register register_hook
+              plugin_setting realms realm realm_providers register register_hook
               register_plugin request var
               /
         ]


### PR DESCRIPTION
Realms with no priority will be assigned a priority of 0 and realms are checked in descending numerical order of priority. Realms having the same priority are checked in random order (due to Perl's hash order randomisation).