### PR TITLE
Transparent (no redirect) login

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ t/plugin-provider-config.t
 t/plugin-provider-config-extended.t
 t/lib/environments/disable-roles.yml
 t/lib/environments/exploding.yml
+t/lib/environments/login-without-redirect.yml
 t/lib/environments/no-default-pages.yml
 t/lib/environments/no-get-user-details.yml
 t/lib/environments/no-login-handler.yml

--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,8 @@ t/lib/Provider/ConfigExtended.pm
 t/lib/Provider/Exploding.pm
 t/lib/Provider/NoGetUserDetails.pm
 t/lib/views/.placeholder
+t/lib/views/login-without-redirect/custom_login.tt
+t/lib/views/login-without-redirect/layouts/main.tt
 t/lib/public/.placeholder
 t/lib/lib/.placeholder
 t/manifest.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ t/00-load.t
 t/01-role-provider.t
 t/disable_roles.t
 t/exploding-provider.t
+t/login-without-redirect.t
 t/plugin-provider-config.t
 t/plugin-provider-config-extended.t
 t/lib/environments/disable-roles.yml
@@ -43,6 +44,7 @@ lib/Dancer2/Plugin/Auth/Extensible/Test/App.pm
 lib/Dancer2/Plugin/Auth/Extensible.pm
 share/views/login.tt
 share/views/login_denied.tt
+share/views/transparent_login.tt
 MANIFEST
 MANIFEST.SKIP
 bin/dancer2-generate-crypted-password

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,6 +39,7 @@ WriteMakefile(
         'File::Share'       => 0,
         'Module::Runtime'   => 0,
         'Crypt::SaltedHash' => 0,
+        'HTTP::BrowserDetect' => 0,
         'List::Util'        => 0,
         'Moo'               => '2.000000',
         'Moo::Role'         => 0,

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1456,6 +1456,30 @@ redirected to the access denied URL.
 If C<disable_roles> configuration option is set to a true value then using
 L</require_all_roles> will cause the application to croak on load.
 
+=head1 NO-REDIRECT LOGIN
+
+By default when a page is requested that requires login and the user is not
+logged in then the plugin redirects the user to the L</login_page> and sets
+C<return_url> to the page originally requested. After successful login the
+user is redirected to the originally-requested page.
+
+As an alternative if L</login_without_redirect> is true then the login
+process happens with no redirects. Instead a C<401> C<Unauthorized> code
+is returned and a login page is displayed. This login page is posted to the
+original URI and on successful login an internal L<Dancer2::Manual/forward>
+is performed so that the originally requested page is displayed. Any
+L<Dancer2::Manual/params> from the original request are added to the
+forward so that they are available to the page's route handler either using
+L<Dancer2::Manual/params> or L<Dancer2::Manual/query_parameters>.
+
+This relies on the login form having no C<action> set and also it must use
+C<__auth_extensible_username> and C<__auth_extensible_password> input names.
+Optionally  C<__auth_extensible_realm> can also be used in a custom login
+page.
+
+See L<http://shadow.cat/blog/matt-s-trout/humane-login-screens/> for the
+original idea for this functionality.
+
 =head1 CUSTOMISING C</login> AND C</login/denied>
 
 =head2 login_template
@@ -1465,7 +1489,7 @@ for your custom login page. If this view exists in your application then it
 will be used instead of the default login template.
 
 If you are using L</login_without_redirect> and assuming you are using
-L<Template::Toolkit> then your custom page should be something like this:
+L<Template::Toolkit> then your custom login page should be something like this:
 
     <h1>Login Required</h1>
 
@@ -1494,6 +1518,40 @@ L<Template::Toolkit> then your custom page should be something like this:
         <input type="submit" name="submit_reset" value="Submit">
     </form>
     [%- END -%]
+
+If you are B<not> using L</login_without_redirect> and assuming you are using
+L<Template::Toolkit> then your custom login page should be something like this:
+
+    <h1>Login Required</h1>
+
+    <p>You need to log in to continue.</p>
+
+    [%- IF login_failed -%]
+        <p>LOGIN FAILED</p>
+    [%- END -%]
+
+    <form method="post">
+        <label for="username">Username:</label>
+        <input type="text" name="username" id="username">
+        <br />
+        <label for="password">Password:</label>
+        <input type="password" name="password" id="password">
+        <br />
+        <input type="submit" value="Login">
+
+        [%- IF return_url -%]
+            <input type="hidden" name="return_url" value="[% return_url %]">
+        [%- END -%]
+
+        [%- IF reset_password_handler -%]
+            <h2>Password reset</h2>
+            <p>Enter your username to obtain an email to reset your password</p>
+            <label for="username_reset">Username:</label>
+            <input type="text" name="username_reset" id="username_reset">
+            <input type="submit" name="submit_reset" value="Submit">
+        [%- END -%]
+
+    </form>
 
 =head2 Replacing the default C< /login > and C< /login/denied > routes
 
@@ -1557,51 +1615,19 @@ you can configure them. See below.
 The default routes also contain functionality for a user to perform password
 resets. See the L<PASSWORD RESETS> documentation for more details.
 
-=head2 Keywords
+=head1 KEYWORDS
 
-=over
+The following keywords are provided in additional to the route decorators
+specified in L</CONTROLLING ACCESS TO ROUTES>:
 
-=item require_login
+=head2 logged_in_user
 
-Used to wrap a route which requires a user to be logged in order to access
-it.
-
-    get '/secret' => require_login sub { .... };
-
-=item require_role
-
-Used to wrap a route which requires a user to be logged in as a user with the
-specified role in order to access it.
-
-    get '/beer' => require_role BeerDrinker => sub { ... };
-
-You can also provide a regular expression, if you need to match the role using a
-regex - for example:
-
-    get '/beer' => require_role qr/Drinker$/ => sub { ... };
-
-=item require_any_role
-
-Used to wrap a route which requires a user to be logged in as a user with any
-one (or more) of the specified roles in order to access it.
-
-    get '/foo' => require_any_role [qw(Foo Bar)] => sub { ... };
-
-=item require_all_roles
-
-Used to wrap a route which requires a user to be logged in as a user with all
-of the roles listed in order to access it.
-
-    get '/foo' => require_all_roles [qw(Foo Bar)] => sub { ... };
-
-
-=item logged_in_user
-
-Returns a hashref of details of the currently logged-in user, if there is one.
+Returns a hashref of details of the currently logged-in user or some kind of
+user object, if there is one.
 
 The details you get back will depend upon the authentication provider in use.
 
-=item get_user_details
+=head2 get_user_details
 
 Returns a hashref of details of the specified user. The realm can optionally
 be specified as the second parameter. If the realm is not specified, each
@@ -1609,7 +1635,7 @@ realm will be checked, and the first matching user will be returned.
 
 The details you get back will depend upon the authentication provider in use.
 
-=item user_has_role
+=head2 user_has_role
 
 Check if a user has the role named.
 
@@ -1625,7 +1651,7 @@ You can also provide the username to check;
 If C<disable_roles> configuration option is set to a true value then using
 L</user_has_role> will cause the application to croak at runtime.
 
-=item user_roles
+=head2 user_roles
 
 Returns a list of the roles of a user.
 
@@ -1637,7 +1663,7 @@ Returns a list or arrayref depending on context.
 If C<disable_roles> configuration option is set to a true value then using
 L</user_roles> will cause the application to croak at runtime.
 
-=item authenticate_user
+=head2 authenticate_user
 
 Usually you'll want to let the built-in login handling code deal with
 authenticating users, but in case you need to do it yourself, this keyword
@@ -1658,7 +1684,7 @@ you can supply the realm as an optional third parameter.
 In boolean context, returns simply true or false; in list context, returns
 C<($success, $realm)>.
 
-=item logged_in_user_lastlogin
+=head2 logged_in_user_lastlogin
 
 Returns (as a DateTime object) the time of the last successful login of the
 current logged in user.
@@ -1667,7 +1693,7 @@ To enable this functionality, set the configuration key C<record_lastlogin> to
 a true value. The backend provider must support write access for a user and
 have lastlogin functionality implemented.
 
-=item update_user
+=head2 update_user
 
 Updates a user's details. If the authentication provider supports it, this
 keyword allows a user's details to be updated within the backend data store.
@@ -1689,7 +1715,7 @@ Otherwise, the realm must be specified with the realm key.
 
 The updated user's details are returned, as per L<logged_in_user>.
 
-=item update_current_user
+=head2 update_current_user
 
 The same as L<update_user>, but does not take a username as the first parameter,
 instead updating the currently logged-in user.
@@ -1699,7 +1725,7 @@ instead updating the currently logged-in user.
 
 The updated user's details are returned, as per L<logged_in_user>.
 
-=item create_user
+=head2 create_user
 
 Creates a new user, if the authentication provider supports it. Optionally
 sends a welcome message with a password reset request, in which case an
@@ -1753,7 +1779,7 @@ L<password_reset_send_email>.
 
 =back
 
-=item password_reset_send
+=head2 password_reset_send
 
 L</password_reset_send> sends a user an email with a password reset link. Along
 with L</user_password>, it allows a user to reset their password.
@@ -1853,7 +1879,7 @@ Here is an example subroutine:
 
 =back
 
-=item user_password
+=head2 user_password
 
 This provides various functions to check or reset a user's password, either
 from a reset code that was previously send by L<password_reset_send> or
@@ -1897,7 +1923,7 @@ Force set a specific user's password, without checking existing password:
 
     user_password username => 'jbloggs', new_password => 'secret'
 
-=item logged_in_user_password_expired
+=head2 logged_in_user_password_expired
 
 Returns true if the password of the currently logged in user has expired.  To
 use this functionality, the provider must support the C<password_expired>
@@ -1918,8 +1944,6 @@ that a check is done in the C<before> hook:
             redirect '/password_update' unless request->uri eq '/password_update';
         }
     }
-
-=back
 
 =head2 PASSWORD RESETS
 
@@ -1985,6 +2009,10 @@ In your application's configuation file:
             # will cause app to croak on load. Use of 'user_roles' and
             # 'user_has_role' will croak at runtime.
             disable_roles: 0
+            # Set to 1 to use the no-redirect login functionality
+            login_without_redirect: 0
+            # Set the view name for a custom login page, defaults to 'login'
+            login_template: login
             # After /login: If no return_url is given: land here ('/' is default)
             user_home_page: '/user'
             # After /logout: If no return_url is given: land here (no default)
@@ -2030,7 +2058,7 @@ the currently logged in user.
 Please see L<Dancer2::Core::Session> for information on how to configure session 
 management within your application.
 
-=head1 FUNCTIONS
+=head1 METHODS
 
 =head2 auth_provider($dsl, $realm)
 
@@ -2130,6 +2158,8 @@ Gabor Szabo (GH #11, #16, #18).
 Evan Brown (GH #20, #32).
 
 Jason Lewis (Unix provider problem).
+
+Matt S. Trout (mst) for L<Zero redirect login the easy and friendly way|http://shadow.cat/blog/matt-s-trout/humane-login-screens/>.
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -334,15 +334,15 @@ sub BUILD {
                 my $request = $app->request;
 
                 # See if this is actually a POST login.
-                my $username = $request->body_parameters->delete(
+                my $username = $request->body_parameters->get(
                     '__auth_extensible_username');
 
-                my $password = $request->body_parameters->delete(
+                my $password = $request->body_parameters->get(
                     '__auth_extensible_password');
 
                 if ( defined $username && defined $password ) {
 
-                    my $auth_realm = $request->body_parameters->delete(
+                    my $auth_realm = $request->body_parameters->get(
                         '__auth_extensible_realm');
 
                     my ( $success, $realm ) =

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -322,7 +322,7 @@ sub BUILD {
     if ( $plugin->login_without_redirect ) {
         # Add a post route so we can catch transparent login.
         # This is a little sucky but since no hooks are called before
-        # route dispatch then adding this willdcard routes now does at
+        # route dispatch then adding this wildcard route now does at
         # least make sure is gets added before any routes that use this
         # plugin's route decorators are added.
         $plugin->app->add_route(

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1410,9 +1410,7 @@ required methods, and you're good to go!
 
 Keywords are provided to check if a user is logged in / has appropriate roles.
 
-=over
-
-=item require_login - require the user to be logged in
+=head2 require_login - require the user to be logged in
 
     get '/dashboard' => require_login sub { .... };
 
@@ -1420,7 +1418,7 @@ If the user is not logged in, they will be redirected to the login page URL to
 log in.  The default URL is C</login> - this may be changed with the
 C<login_page> option.
 
-=item require_role - require the user to have a specified role
+=head2 require_role - require the user to have a specified role
 
     get '/beer' => require_role BeerDrinker => sub { ... };
 
@@ -1432,7 +1430,7 @@ to the access denied URL.
 If C<disable_roles> configuration option is set to a true value then using
 L</require_role> will cause the application to croak on load.
 
-=item require_any_roles - require the user to have one of a list of roles
+=head2 require_any_roles - require the user to have one of a list of roles
 
     get '/drink' => require_any_role [qw(BeerDrinker VodaDrinker)] => sub {
         ...
@@ -1446,7 +1444,7 @@ roles, they will be redirected to the access denied URL.
 If C<disable_roles> configuration option is set to a true value then using
 L</require_any_roles> will cause the application to croak on load.
 
-=item require_all_roles - require the user to have all roles listed
+=head2 require_all_roles - require the user to have all roles listed
 
     get '/foo' => require_all_roles [qw(Foo Bar)] => sub { ... };
 
@@ -1458,9 +1456,46 @@ redirected to the access denied URL.
 If C<disable_roles> configuration option is set to a true value then using
 L</require_all_roles> will cause the application to croak on load.
 
-=back
+=head1 CUSTOMISING C</login> AND C</login/denied>
 
-=head2 Replacing the Default C< /login > and C< /login/denied > Routes
+=head2 login_template
+
+The L</login_template> setting determines the name of the view you use
+for your custom login page. If this view exists in your application then it
+will be used instead of the default login template.
+
+If you are using L</login_without_redirect> and assuming you are using
+L<Template::Toolkit> then your custom page should be something like this:
+
+    <h1>Login Required</h1>
+
+    <p>You need to log in to continue.</p>
+
+    [%- IF login_failed -%]
+        <p>LOGIN FAILED</p>
+    [%- END -%]
+
+    <form method="post">
+        <label for="username">Username:</label>
+        <input type="text" name="__auth_extensible_username" id="username">
+        <br />
+        <label for="password">Password:</label>
+        <input type="password" name="__auth_extensible_password" id="password">
+        <br />
+        <input type="submit" value="Login">
+    </form>
+
+    [%- IF reset_password_handler -%]
+    <form method="post" action="[% login_page %]">
+        <h2>Password reset</h2>
+        <p>Enter your username to obtain an email to reset your password</p>
+        <label for="username_reset">Username:</label>
+        <input type="text" name="username_reset" id="username_reset">
+        <input type="submit" name="submit_reset" value="Submit">
+    </form>
+    [%- END -%]
+
+=head2 Replacing the default C< /login > and C< /login/denied > routes
 
 By default, the plugin adds a route to present a simple login form at that URL.
 If you would rather add your own, set the C<no_default_pages> setting to a true

--- a/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
@@ -1547,13 +1547,10 @@ sub _roles {
 
         my $res = get('/not_allroles');
 
-        is( $res->code, 302, "/not_allroles response code 302" )
+        is( $res->code, 403, "/not_allroles response code 403" )
           or diag explain $trap->read;
-        is(
-            $res->headers->header('Location'),
-            'http://localhost/login/denied?return_url=%2Fnot_allroles',
-            '/not_allroles redirected to denied page'
-        );
+        like $res->content, qr/Permission Denied/,
+          "... and we got the Permission Denied page.";
     }
 
     {
@@ -1573,15 +1570,11 @@ sub _roles {
 
         my $res = get('/piss');
 
-        is( $res->code, 302,
-            "Redirect on a route requiring a role we don't have" )
+        is( $res->code, 403,
+            "route requiring a role we don't have gets response code 403" )
           or diag explain $trap->read;
-
-        is(
-            $res->headers->header('Location'),
-            'http://localhost/login/denied?return_url=%2Fpiss',
-            "We cannot request a route requiring a role we don't have"
-        );
+        like $res->content, qr/Permission Denied/,
+          "... and we got the Permission Denied page.";
     }
 
     # 2 arg user_has_role

--- a/share/views/transparent_login.tt
+++ b/share/views/transparent_login.tt
@@ -1,0 +1,27 @@
+<h1>Login Required</h1>
+
+<p>You need to log in to continue.</p>
+
+[%- IF login_failed -%]
+  <p>LOGIN FAILED</p>
+[%- END -%]
+
+<form method="post">
+  <label for="username">Username:</label>
+  <input type="text" name="__auth_extensible_username" id="username">
+  <br />
+  <label for="password">Password:</label>
+  <input type="password" name="__auth_extensible_password" id="password">
+  <br />
+  <input type="submit" value="Login">
+</form>
+
+<form method="post" action="[% login_page %]">
+  [%- IF reset_password_handler -%]
+    <h2>Password reset</h2>
+    <p>Enter your username to obtain an email to reset your password</p>
+    <label for="username_reset">Username:</label>
+    <input type="text" name="username_reset" id="username_reset">
+    <input type="submit" name="submit_reset" value="Submit">
+  [%- END -%]
+</form>

--- a/t/lib/environments/login-without-redirect.yml
+++ b/t/lib/environments/login-without-redirect.yml
@@ -1,3 +1,5 @@
+template: tiny
+layout: main
 plugins:
     Auth::Extensible:
         record_lastlogin: 1

--- a/t/lib/environments/login-without-redirect.yml
+++ b/t/lib/environments/login-without-redirect.yml
@@ -1,0 +1,40 @@
+plugins:
+    Auth::Extensible:
+        record_lastlogin: 1
+        login_without_redirect: 1
+        realms:
+            config1:
+                provider: Provider::ConfigExtended
+                password_expiry_days: 2
+                users:
+                    - user: dave
+                      pass: beer
+                      name: "David Precious"
+                      roles:
+                          - BeerDrinker
+                          - Motorcyclist
+                    - user: bob
+                      pass: cider
+                      name: "Bob Smith"
+                      roles:
+                          - CiderDrinker
+                    - user: mark
+                      pass: wantscider
+                      name: "Update here"
+            config2:
+                provider: Provider::ConfigExtended
+                priority: 10
+                users:
+                    - user: burt
+                      pass: bacharach
+                    - user: hashedpassword
+                      pass: "{SSHA}+2u1HpOU7ak6iBR6JlpICpAUvSpA/zBM"
+                    - user: mark
+                      pass: wantscider
+                      name: "Update here"
+            config3:
+                provider: Provider::ConfigExtended
+                priority: 2
+                users:
+                    - user: bananarepublic
+                      pass: whatever

--- a/t/lib/views/login-without-redirect/custom_login.tt
+++ b/t/lib/views/login-without-redirect/custom_login.tt
@@ -1,0 +1,27 @@
+<h1>Custom Login Page</h1>
+
+<p>You must log in to continue.</p>
+
+[%- IF login_failed -%]
+  <p>LOGIN FAILED</p>
+[%- END -%]
+
+<form method="post">
+  <label for="username">Username:</label>
+  <input type="text" name="__auth_extensible_username" id="username">
+  <br />
+  <label for="password">Password:</label>
+  <input type="password" name="__auth_extensible_password" id="password">
+  <br />
+  <input type="submit" value="Login">
+</form>
+
+<form method="post" action="[% login_page %]">
+  [%- IF reset_password_handler -%]
+    <h2>Password reset</h2>
+    <p>Enter your username to obtain an email to reset your password</p>
+    <label for="username_reset">Username:</label>
+    <input type="text" name="username_reset" id="username_reset">
+    <input type="submit" name="submit_reset" value="Submit">
+  [%- END -%]
+</form>

--- a/t/lib/views/login-without-redirect/layouts/main.tt
+++ b/t/lib/views/login-without-redirect/layouts/main.tt
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>This text is in the layout</p>
+[% content %]
+</body>
+</html>

--- a/t/login-without-redirect.t
+++ b/t/login-without-redirect.t
@@ -9,10 +9,10 @@ use HTTP::Cookies;
 BEGIN {
     $ENV{DANCER_CONFDIR}     = 't/lib';
     $ENV{DANCER_ENVIRONMENT} = 'login-without-redirect';
+    $ENV{DANCER_VIEWS}       = 't/lib/views/login-without-redirect';
 }
 
 {
-
     package TestApp;
     use lib 't/lib';
     use Dancer2;
@@ -21,14 +21,27 @@ BEGIN {
     set logger => 'capture';
     set log    => 'debug';
 
+    get '/use_custom_login_template' => sub {
+        my $plugin = app->with_plugin('Auth::Extensible');
+        $plugin->{login_template} = 'custom_login';
+    };
+    get '/use_builtin_login_template' => sub {
+        my $plugin = app->with_plugin('Auth::Extensible');
+        $plugin->{login_template} = 'login';
+    };
     get '/loggedin' => require_login sub {
         "You are logged in";
     };
-
+    post '/protected_post' => require_login sub {
+        my $params = params;
+        send_as YAML => [ "You are logged in", $params ];
+    };
     get '/beer' => require_role BeerDrinker => sub {
         "Have some beer";
     };
-
+    get '/cider' => require_role CiderDrinker => sub {
+        "Have some cider";
+    };
 }
 
 my $app = Dancer2->runner->psgi_app;
@@ -39,13 +52,131 @@ my $trap = TestApp->dancer_app->logger_engine->trapper;
 my $url  = 'http://localhost';
 my $jar  = HTTP::Cookies->new();
 
-my %ua = ( 'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML like Gecko) Chrome/21.0.1180.83 Safari/537.1' );
-
 {
-    my $res = $test->request( GET "$url/loggedin", %ua );
+    # WWW-Authenticate robot header
+
+    my $req = GET "$url/loggedin";
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
     $jar->extract_cookies($res);
+
     is $res->code, 401,
-      "Trying a protected page with real User-Agent header gets 401 response";
+      "Trying a require_login page with *no* User-Agent header gets 401";
+    like $res->header('www-authenticate'), qr/Basic realm=/,
+      "... and we have a WWW-Authenticate header with Basic realm";
+    like $res->content, qr/You need to log in to continue/,
+      "... and we can see a login form";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field";
+    like $res->content, qr/This text is in the layout/,
+      "... and the response is wrapped in the layout.";
+}
+{
+    # WWW-Authenticate real user (non-robot) header
+
+    my $req = GET "$url/loggedin",
+        'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML like Gecko) Chrome/21.0.1180.83 Safari/537.1';
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
+    $jar->extract_cookies($res);
+
+    is $res->code, 401,
+      "Trying a require_login page with real User-Agent header gets 401";
+    like $res->header('www-authenticate'), qr/FormBased.+use form to log in/,
+      "... and we have a WWW-Authenticate header which says use the form";
+    like $res->content, qr/You need to log in to continue/,
+      "... and we can see a login form";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field";
+    like $res->content, qr/This text is in the layout/,
+      "... and the response is wrapped in the layout.";
+
+}
+{
+    # cutom login_template
+
+    $test->request(GET '/use_custom_login_template');
+
+    my $req = GET "$url/loggedin";
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
+    $jar->extract_cookies($res);
+
+    is $res->code, 401,
+      "Trying a require_login page with custom login_template gets 401";
+    like $res->header('www-authenticate'), qr/Basic realm=/,
+      "... and we have a WWW-Authenticate header with Basic realm";
+    like $res->content, qr/Custom Login Page/,
+      "... and we can see our custom login form";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field";
+    like $res->content, qr/This text is in the layout/,
+      "... and the response is wrapped in the layout.";
+
+    $test->request(GET '/use_builtin_login_template');
+
+}
+{
+    # bad login
+
+    $trap->read;
+    my $req =
+      POST "$url/loggedin",
+      [
+        __auth_extensible_username => 'dave',
+        __auth_extensible_password => 'cider',
+      ];
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
+    $jar->extract_cookies($res);
+
+    is $res->code, 401,
+      "Try posting bad login details to a require_login page gets 401 response"
+          or diag explain $trap->read;
+    like $res->content, qr/You need to log in to continue/,
+      "... and we can see a login form";
+    like $res->content, qr/LOGIN FAILED/,
+      "... and we see LOGIN FAILED";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field";
+    like $res->content, qr/This text is in the layout/,
+      "... and the response is wrapped in the layout.";
+}
+{
+    # good login
+
+    $trap->read;
+    my $req =
+      POST "$url/loggedin",
+      [
+        __auth_extensible_username => 'dave',
+        __auth_extensible_password => 'beer',
+      ];
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
+    $jar->extract_cookies($res);
+
+    ok $res->is_success,
+      "Try posting real login details to a require_login page is_success"
+          or diag explain $trap->read;
+    is $res->content, "You are logged in",
+      "... and we see the real page content." or diag explain $trap->read;
+
+    # logout
+    $req = GET '/logout';
+    $jar->add_cookie_header($req);
+    $test->request( $req );
+}
+done_testing;
+__END__
+{
+    my $req = GET "$url/beer", %ua;
+    $jar->add_cookie_header($req);
+    my $res = $test->request( $req );
+    $jar->extract_cookies($res);
+
+    is $res->code, 401,
+      "Trying a require_role page gets 401 response";
     like $res->header('www-authenticate'), qr/FormBased.+use form to log in/,
       "... and we have a WWW-Authenticate header which says use the form";
     like $res->content, qr/You need to log in to continue/,
@@ -54,11 +185,6 @@ my %ua = ( 'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTM
       "... and we see __auth_extensible_username field.";
 
 }
-{
-    my $res = $test->request( GET "$url/loggedin" );
-    $jar->extract_cookies($res);
-    is $res->code, 401,
-      "Trying a protected page with *no* User-Agent header gets 401 response";
     like $res->header('www-authenticate'), qr/Basic realm=/,
       "... and we have a WWW-Authenticate header with Basic realm";
     like $res->content, qr/You need to log in to continue/,

--- a/t/login-without-redirect.t
+++ b/t/login-without-redirect.t
@@ -1,0 +1,112 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Test;
+use HTTP::Request::Common;
+use HTTP::Cookies;
+
+BEGIN {
+    $ENV{DANCER_CONFDIR}     = 't/lib';
+    $ENV{DANCER_ENVIRONMENT} = 'login-without-redirect';
+}
+
+{
+
+    package TestApp;
+    use lib 't/lib';
+    use Dancer2;
+    use Dancer2::Plugin::Auth::Extensible;
+
+    set logger => 'capture';
+    set log    => 'debug';
+
+    get '/loggedin' => require_login sub {
+        "You are logged in";
+    };
+
+    get '/beer' => require_role BeerDrinker => sub {
+        "Have some beer";
+    };
+
+}
+
+my $app = Dancer2->runner->psgi_app;
+is( ref $app, 'CODE', 'Got app' );
+
+my $test = Plack::Test->create($app);
+my $trap = TestApp->dancer_app->logger_engine->trapper;
+my $url  = 'http://localhost';
+my $jar  = HTTP::Cookies->new();
+
+my %ua = ( 'User-Agent' => 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML like Gecko) Chrome/21.0.1180.83 Safari/537.1' );
+
+{
+    my $res = $test->request( GET "$url/loggedin", %ua );
+    $jar->extract_cookies($res);
+    is $res->code, 401,
+      "Trying a protected page with real User-Agent header gets 401 response";
+    like $res->header('www-authenticate'), qr/FormBased.+use form to log in/,
+      "... and we have a WWW-Authenticate header which says use the form";
+    like $res->content, qr/You need to log in to continue/,
+      "... and we can see a login form";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field.";
+
+}
+{
+    my $res = $test->request( GET "$url/loggedin" );
+    $jar->extract_cookies($res);
+    is $res->code, 401,
+      "Trying a protected page with *no* User-Agent header gets 401 response";
+    like $res->header('www-authenticate'), qr/Basic realm=/,
+      "... and we have a WWW-Authenticate header with Basic realm";
+    like $res->content, qr/You need to log in to continue/,
+      "... and we can see a login form";
+    like $res->content, qr/input.+name="__auth_extensible_username/,
+      "... and we see __auth_extensible_username field.";
+}
+done_testing;
+__END__
+{
+    my $req = POST "$url/login", [ username => 'dave', password => 'bad' ];
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "POST /login with bad password response is OK";
+    is $res->content, "Not allowed", "... and we see our custom response.";
+}
+{
+    my $req = GET "$url/loggedin";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_redirect, "... and we still cannot reach protected page.";
+}
+{
+    my $req = POST "$url/login", [ username => 'dave', password => 'beer' ];
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "POST /login with good password response is OK";
+    is $res->content, "Welcome!", "... and we see our custom response";
+}
+{
+    my $req = GET "$url/loggedin";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "... and we can reach protected page";
+    is $res->content,    "You are logged in",
+      "... which has the content we expect.";
+}
+{
+    my $req = GET "$url/logout";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_success, "/logout is successful";
+}
+{
+    my $req = GET "$url/loggedin";
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    ok $res->is_redirect, "... and we can no longer reach protected page.";
+}
+
+done_testing;


### PR DESCRIPTION
See: http://shadow.cat/blog/matt-s-trout/humane-login-screens/
and: https://github.com/melmothx/amusewiki/blob/17abee075b5c00e569706165cb3275aa84f96a2f/lib/AmuseWikiFarm/Role/Controller/HumanLoginScreen.pm#L148-L165

**This is a work in progress**

The basic idea is that when login is required (via `require_login` or one of the `require_role*` route decorators) instead of redirecting the user to a login page we return 401 with a login page that is submitted to the original page URL using POST. Since the original request might not be a POST we add a wildcard POST route that catches login requests and if successful `forward`s to the original page.