### PR TITLE
added before_logout hook

### DIFF
--- a/README
+++ b/README
@@ -757,6 +757,9 @@ HOOKS
   permission_denied
   after_login_success
     Called after successful login just before redirect is called.
+  
+  before_logout
+    Called just before the session gets destroyed on logout.
 
 AUTHOR
     David Precious, "<davidp at preshweb.co.uk>"

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -212,7 +212,8 @@ has _template_tiny => (
 
 plugin_hooks 'before_authenticate_user', 'after_authenticate_user',
   'before_create_user', 'after_create_user',
-  'login_required', 'permission_denied', 'after_login_success';
+  'login_required', 'permission_denied', 'after_login_success',
+  'before_logout';
 
 #
 # keywords
@@ -1177,6 +1178,8 @@ sub _logout_route {
     my $req = $app->request;
     my $plugin = $app->with_plugin('Auth::Extensible');
 
+    $plugin->execute_plugin_hook( 'before_logout' );
+
     $app->destroy_session;
 
     if ( my $url = $req->parameters->get('return_url') ) {
@@ -2119,6 +2122,10 @@ reference of any errors from the main method or from the provider.
 =head2 after_login_success
 
 Called after successful login just before redirect is called.
+
+=head2 before_logout
+
+Called just before the session gets destroyed on logout.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Sometimes it would be good to do some cleanup on user logout. I suggest to add a hook called `before_logout` that still has the session information available to tidy up.

I did not find any existing tests for hooks, so I did not add one, too :-/
Maybe you can point me to the place where to add such tests.