### PR TITLE
Fixes #74

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1246,10 +1246,13 @@ sub _post_login_route {
         }
     }
 
+    my $return_url_escaped = uri_unescape(
+        $app->request->parameters->get('return_url')
+    );
+
     if ( $plugin->logged_in_user ) {
         # uncoverable condition false
-        $app->redirect( $app->request->parameters->get('return_url')
-              || $plugin->user_home_page );
+        $app->redirect( $return_url_escaped || $plugin->user_home_page );
     }
 
     my $auth_realm = $params->{realm} || $params->{__auth_extensible_realm};
@@ -1267,9 +1270,6 @@ sub _post_login_route {
         $app->log( core => "Realm is $realm" );
         $plugin->execute_plugin_hook( 'after_login_success' );
         # uncoverable condition false
-        my $return_url_escaped = uri_unescape(
-            $app->request->parameters->get('return_url')
-        );
         $app->redirect( $return_url_escaped || $plugin->user_home_page );
     }
     else {

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1267,8 +1267,10 @@ sub _post_login_route {
         $app->log( core => "Realm is $realm" );
         $plugin->execute_plugin_hook( 'after_login_success' );
         # uncoverable condition false
-        $app->redirect( $app->request->parameters->get('return_url')
-              || $plugin->user_home_page );
+        my $return_url_escaped = uri_unescape(
+            $app->request->parameters->get('return_url')
+        );
+        $app->redirect( $return_url_escaped || $plugin->user_home_page );
     }
     else {
         $app->request->vars->{login_failed}++;


### PR DESCRIPTION
There's actually two problems in #74 : 

1. An issue with not escaping the root slash.  This is fixed by this PR (uri_unescape the return_url before redirecting to it).

2.  The other issue is the application path being replicated on redirect.  I think that the issue there is that the request_uri contains the application path.  I think this is an issue (idiosyncrasy - I'm hesitant to call it a bug) with Dancer2.  A similar issue was reported in https://github.com/PerlDancer/Dancer2/issues/1135. 