### PR TITLE
renamed password generator script in docs

### DIFF
--- a/README
+++ b/README
@@ -17,8 +17,8 @@ DESCRIPTION
     extensible as possible, and to make secure password handling easy. The
     base class for auth providers makes handling RFC2307-style hashed
     passwords really simple, so you have no excuse for storing plain-text
-    passwords. A simple script called generate-crypted-password to generate
-    RFC2307-style hashed passwords is included, or you can use
+    passwords. A simple script called dancer2-generate-crypted-password to
+    generate RFC2307-style hashed passwords is included, or you can use
     Crypt::SaltedHash yourself to do so, or use the slappasswd utility if
     you have it installed.
 

--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -1330,7 +1330,7 @@ Designed to support multiple authentication realms and to be as extensible as
 possible, and to make secure password handling easy.  The base class for auth
 providers makes handling C<RFC2307>-style hashed passwords really simple, so you
 have no excuse for storing plain-text passwords.  A simple script called
-B<generate-crypted-password> to generate
+B<dancer2-generate-crypted-password> to generate
 RFC2307-style hashed passwords is included, or you can use L<Crypt::SaltedHash>
 yourself to do so, or use the C<slappasswd> utility if you have it installed.
 


### PR DESCRIPTION
The script name was wrong and it took me a while to find out what was wrong. This PR fixes the documentation.