### PR TITLE
change return_url back to path (instead of request_uri)

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -998,7 +998,7 @@ sub _check_for_login {
     # old-fashioned redirect to login page with return_url set
     return $plugin->app->redirect(
         $request->uri_for(
-            $plugin->login_page, { return_url => $request->request_uri }
+            $plugin->login_page, { return_url => $request->path }
         )
     );
 }

--- a/t/lib/environments/return_url.yml
+++ b/t/lib/environments/return_url.yml
@@ -1,0 +1,37 @@
+plugins:
+    Auth::Extensible:
+        realms:
+            config1:
+                provider: Config
+                users:
+                    - user: dave
+                      pass: beer
+                      name: "David Precious"
+                      roles:
+                          - BeerDrinker
+                          - Motorcyclist
+                    - user: bob
+                      pass: cider
+                      name: "Bob Smith"
+                      roles:
+                          - CiderDrinker
+                    - user: mark
+                      pass: wantscider
+                      name: "Update here"
+            config2:
+                provider: Config
+                priority: 10
+                users:
+                    - user: burt
+                      pass: bacharach
+                    - user: hashedpassword
+                      pass: "{SSHA}+2u1HpOU7ak6iBR6JlpICpAUvSpA/zBM"
+                    - user: mark
+                      pass: wantscider
+                      name: "Update here"
+            config3:
+                provider: Config
+                priority: 2
+                users:
+                    - user: bananarepublic
+                      pass: whatever

--- a/t/return_url.t
+++ b/t/return_url.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Plack::App::URLMap;
+use Plack::Test;
+use HTTP::Request::Common;
+use Data::Dumper;
+use URI::URL;
+use HTTP::Cookies;
+
+BEGIN {
+    $ENV{DANCER_CONFDIR}     = 't/lib';
+    $ENV{DANCER_ENVIRONMENT} = 'return_url';
+}
+
+{ 
+    package TestApp;
+    use Dancer2;
+    use Dancer2::Plugin::Auth::Extensible;
+
+    get '/restricted' => require_login sub {
+        return "Welcome!";
+    };
+}
+
+my $app = Plack::App::URLMap->new;
+$app->mount("/mypath" => TestApp->to_app);
+my $test = Plack::Test->create($app);
+
+my $jar  = HTTP::Cookies->new();
+my $res = $test->request(GET '/mypath/restricted');
+$jar->extract_cookies($res);
+ok($res->code == 302, "Checking response code redirect (302)");
+#ok(($res->header('Location') eq 'http://localhost/mypath/login?return_url=%2Frestricted'), "Checking Location in 302 Header");
+
+my $uri = URI::URL->new($res->header('Location'));
+my $return_url = $uri->query;
+$return_url =~ s/return_url=//;
+my $url  = $res->header('Location');
+
+{
+    my $req = POST $url, [ username => 'dave', password => 'beer', return_url => $return_url ];
+    $jar->add_cookie_header($req);
+    my $res = $test->request($req);
+    $jar->extract_cookies($res);
+    
+    my $n_req = GET $res->header('Location');
+    $jar->add_cookie_header($n_req);
+    ok($n_req->url !~ m#/mypath/mypath/#, "Checking duplicate mount path");
+    $res = $test->request($n_req);
+    ok($res->code != 404, "Checking response code not 404");
+    $jar->extract_cookies($res);
+
+    ok $res->is_success, "POST /login with good password response is OK";
+    is $res->content, "Welcome!", "... and we see our custom response";
+}


### PR DESCRIPTION
Please be aware that this patch reverts commit 46cc867 and I'm not sure if this is desirable.

Without this patch, if you use Plack::Builder and prefix the mount
with a path like:
```
builder {  mount '/mypath' => 'MyApp' };
```
the redirect will go to '/mypath/mypath/'