### PR TITLE
Run tests in a reliable order

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
@@ -104,7 +104,7 @@ sub runtests {
 
     @provider_can = @$ret;
 
-    my @to_test = ($ENV{D2PAE_TEST_ONLY}) || keys %dispatch;
+    my @to_test = ($ENV{D2PAE_TEST_ONLY}) || sort keys %dispatch;
 
     foreach my $test ( @to_test ) {
         my @missing;


### PR DESCRIPTION
This might help avoid the intermittent test failures in Dancer2::Plugin::Auth::Extensible::DBIC described at https://github.com/ctrlo/Dancer2-Plugin-Auth-Extensible-Provider-DBIC/issues/18