### PR TITLE
dancer2-generated-crypted-password: use SHA-512 instead of SHA-1

### DIFF
--- a/bin/dancer2-generate-crypted-password
+++ b/bin/dancer2-generate-crypted-password
@@ -16,7 +16,7 @@ if ($@) {
 }
 
 
-my $csh = Crypt::SaltedHash->new(algorithm => 'SHA-1');
+my $csh = Crypt::SaltedHash->new(algorithm => 'SHA-512');
 $csh->add($plain_text);
 my $salted = $csh->generate;
 


### PR DESCRIPTION
Updates dancer2-generated-crypted-password to accord with #57.

Thanks for considering this PR!