### PR TITLE
Update tests to match RFC 7231 behavior of Dancer2.

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
@@ -80,6 +80,8 @@ my %dependencies = (
 
 my ( $test, $trap );
 
+my $EXPECTED_REDIRECT_TARGET;
+
 sub testme {
     BAIL_OUT "Please upgrade your provider to the latest version. Dancer2::Plugin::Auth::Extensible no longer supports the old \"testme\" tests.";
 }
@@ -90,6 +92,7 @@ my @provider_can;
 sub runtests {
     my $app = shift;
 
+    $EXPECTED_REDIRECT_TARGET = $Dancer2::VERSION gt '0.300000' ? '/' : 'http://localhost/';
     $test = Plack::Test->create($app);
     $trap = TestApp->dancer_app->logger_engine->trapper;
 
@@ -801,7 +804,7 @@ sub _login_logout {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check session_data again
@@ -819,7 +822,7 @@ sub _login_logout {
     $res = get('/login');
     ok $res->is_redirect, "GET /login whilst logged in is redirected."
       or diag explain $res;
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # get /login whilst already logged in with return_url set
@@ -840,7 +843,7 @@ sub _login_logout {
 
     $res = get('/logout');
     ok $res->is_redirect, "GET /logout is_redirect" or diag explain $res;
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check session_data again
@@ -857,7 +860,7 @@ sub _login_logout {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check session_data again
@@ -979,7 +982,7 @@ sub _login_logout {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            '/',
+            $EXPECTED_REDIRECT_TARGET,
             '/logout redirected to / (exit_page) after logging out' );
     }
 
@@ -1031,7 +1034,7 @@ sub _logged_in_user {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check logged_in_user again
@@ -1054,7 +1057,7 @@ sub _logged_in_user {
 
     $res = get('/logout');
     ok $res->is_redirect, "GET /logout is_redirect" or diag explain $res;
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check logged_in_user again
@@ -1108,7 +1111,7 @@ sub _logged_in_user_lastlogin {
     $res =
       post( '/login', [ username => 'lastlogin1', password => 'lastlogin2' ] );
     ok $res->is_redirect, "POST /login with with new user is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1143,7 +1146,7 @@ sub _logged_in_user_lastlogin {
     $res =
       post( '/login', [ username => 'lastlogin1', password => 'lastlogin2' ] );
     ok $res->is_redirect, "POST /login with with new user is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1361,7 +1364,7 @@ sub _require_login {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), '/',
+    is $res->header('location'), $EXPECTED_REDIRECT_TARGET,
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1611,7 +1614,7 @@ sub _roles {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            '/',
+            $EXPECTED_REDIRECT_TARGET,
             '/logout redirected to / (exit_page) after logging out' );
     }
 
@@ -1707,7 +1710,7 @@ sub _roles {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            '/',
+            $EXPECTED_REDIRECT_TARGET,
             '/logout redirected to / (exit_page) after logging out' );
     }
 

--- a/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Test.pm
@@ -801,7 +801,7 @@ sub _login_logout {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check session_data again
@@ -819,7 +819,7 @@ sub _login_logout {
     $res = get('/login');
     ok $res->is_redirect, "GET /login whilst logged in is redirected."
       or diag explain $res;
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # get /login whilst already logged in with return_url set
@@ -840,7 +840,7 @@ sub _login_logout {
 
     $res = get('/logout');
     ok $res->is_redirect, "GET /logout is_redirect" or diag explain $res;
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check session_data again
@@ -857,7 +857,7 @@ sub _login_logout {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check session_data again
@@ -979,7 +979,7 @@ sub _login_logout {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            'http://localhost/',
+            '/',
             '/logout redirected to / (exit_page) after logging out' );
     }
 
@@ -1031,7 +1031,7 @@ sub _logged_in_user {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check logged_in_user again
@@ -1054,7 +1054,7 @@ sub _logged_in_user {
 
     $res = get('/logout');
     ok $res->is_redirect, "GET /logout is_redirect" or diag explain $res;
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check logged_in_user again
@@ -1108,7 +1108,7 @@ sub _logged_in_user_lastlogin {
     $res =
       post( '/login', [ username => 'lastlogin1', password => 'lastlogin2' ] );
     ok $res->is_redirect, "POST /login with with new user is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1143,7 +1143,7 @@ sub _logged_in_user_lastlogin {
     $res =
       post( '/login', [ username => 'lastlogin1', password => 'lastlogin2' ] );
     ok $res->is_redirect, "POST /login with with new user is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1361,7 +1361,7 @@ sub _require_login {
 
     $res = post( '/login', [ username => 'dave', password => 'beer' ] );
     ok $res->is_redirect, "POST /login with good username/password is_redirect";
-    is $res->header('location'), 'http://localhost/',
+    is $res->header('location'), '/',
       "... and redirect location is correct.";
 
     # check we can reach restricted page
@@ -1611,7 +1611,7 @@ sub _roles {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            'http://localhost/',
+            '/',
             '/logout redirected to / (exit_page) after logging out' );
     }
 
@@ -1707,7 +1707,7 @@ sub _roles {
           or diag explain $trap->read;
 
         is( $res->headers->header('Location'),
-            'http://localhost/',
+            '/',
             '/logout redirected to / (exit_page) after logging out' );
     }
 


### PR DESCRIPTION
Dancer2 PR 1461 updated redirect() behavior to act according to RFC
7231, which superseded RFC 2616. The tests were still expecting
RFC 2616 behavior.