### PR TITLE
Add Test::Fatal to list of dependencies.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,7 @@ WriteMakefile(
         'Test::MockDateTime' => 0,
         'Test::More' => 0,
         'Test::Warnings' => 0,
+        'Test::Fatal' => 0
     },
     PREREQ_PM => {
         'Carp'              => 0,


### PR DESCRIPTION
Test::Fatal is required to run tests. It needs to be listed as a
requirement.