### PR TITLE
Fix config for test

### DIFF
--- a/t/lib/environments/no-login-handler.yml
+++ b/t/lib/environments/no-login-handler.yml
@@ -1,4 +1,4 @@
-logger: trap
+logger: capture
 plugins:
     Auth::Extensible:
         no_login_handler: 1


### PR DESCRIPTION
The logger should be `capture` ... this test fails when Dancer is logging at build.